### PR TITLE
chore: disable Netlify production builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,5 @@
 # Netlify Build Configuration for Vite
-# Note: Make sure to remove the Next.js plugin from Netlify UI:
-# Site Settings → Build & deploy → Build plugins → Remove @netlify/plugin-nextjs
+# Note: Production deploys to GitHub Pages, Netlify is for PR previews only
 
 [build]
   # Build command - runs Vite build (tsc && vite build)
@@ -8,6 +7,9 @@
   
   # Directory to deploy - Vite outputs to dist/
   publish = "dist"
+  
+  # Ignore production builds - only build PR previews
+  ignore = "git branch --show-current | grep -q '^main$'"
 
 # Redirect all requests to index.html for SPA routing
 [[redirects]]
@@ -18,3 +20,18 @@
 # Build environment
 [build.environment]
   NODE_VERSION = "20"
+
+# Deploy contexts - only build PR previews
+[context.production]
+  # Skip production deployments (handled by GitHub Pages)
+  command = "echo 'Skipping production build - deployed via GitHub Pages'"
+  publish = "public"
+
+[context.deploy-preview]
+  # Build PR previews
+  command = "pnpm build"
+  publish = "dist"
+
+[context.branch-deploy]
+  # Skip branch deployments (only PRs should build)
+  command = "echo 'Skipping branch build - only PR previews enabled'"


### PR DESCRIPTION
Configure Netlify to only build PR previews, not production. Production is handled by GitHub Pages.