### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,6 @@
 name: PR Checks
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/hatsyio/personal-portfolio/security/code-scanning/1](https://github.com/hatsyio/personal-portfolio/security/code-scanning/1)

To address this issue, explicitly set the `permissions` key at the top level of the workflow file (immediately below the `name:` field and before the `on:` field). This ensures all jobs within this workflow (unless overridden) will execute with the least required privilege. In this case, none of the shown steps require more than read-only access to the repository contents, so `permissions: contents: read` is suitable, as recommended. Only .github/workflows/pr-checks.yml needs to be changed; no other code or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
